### PR TITLE
Fixed typo in import statement

### DIFF
--- a/musicxml_parser/scoreToPianoroll.py
+++ b/musicxml_parser/scoreToPianoroll.py
@@ -20,8 +20,8 @@ import xml.sax
 import re
 import os
 import tempfile
-from Musicxml_parser.smooth_dynamic import smooth_dyn
-from Musicxml_parser.totalLengthHandler import TotalLengthHandler
+from musicxml_parser.smooth_dynamic import smooth_dyn
+from musicxml_parser.totalLengthHandler import TotalLengthHandler
 
 mapping_step_midi = {
     'C': 0,


### PR DESCRIPTION
Changed "from Musicxml_parser..." to "from musicxml_parser..." on lines 23 and 24, fixing a ModuleNotFoundError